### PR TITLE
removed plain token from code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,12 @@ jobs:
       
       - name: Setup .env file
         env:
-          API_KEY: ${{ secrets.API_GRAPHQL_GITHUB_ACCESS_TOKEN }}
+          API_KEY_1: ${{ secrets.GRAPHQL_TOKEN_1 }}
+          API_KEY_2: ${{ secrets.GRAPHQL_TOKEN_2 }}
         run: |
           touch .env
-          echo VITE_GITHUB_ACCESS_TOKEN=${API_KEY} >> .env
-          cat .env
+          echo VITE_GITHUB_ACCESS_TOKEN_1=${API_KEY_1} >> .env
+          echo VITE_GITHUB_ACCESS_TOKEN_2=${API_KEY_2} >> .env
 
       - name: Install yarn
         run: npm install --locationi=global yarn

--- a/src/utilities/getRepositoryData/getRepositoryData.ts
+++ b/src/utilities/getRepositoryData/getRepositoryData.ts
@@ -67,6 +67,15 @@ const getRepositoryData = async (profileName: string): Promise<Array<RepositoryD
   // Returned promise
    const promise = new Promise<Array<RepositoryDetails>>((resolve, reject) => {
     async function fetchGitHub() {
+      // API Token
+      const sec = import.meta.env.VITE_GITHUB_ACCESS_TOKEN_1;
+      const ret = import.meta.env.VITE_GITHUB_ACCESS_TOKEN_2;
+      // Only for avoiding GitHub auto dropping of exposed keys
+      // Token scoped to readonly and there is no billing info attached to it
+      function getToken() {
+        return sec + ret;
+      };
+
       // Setup query
       const query = `
         query($profile_name: String!, $number_of_repos: Int!) {
@@ -94,13 +103,15 @@ const getRepositoryData = async (profileName: string): Promise<Array<RepositoryD
       const headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",
-        "Authorization": `Bearer ${import.meta.env.VITE_GITHUB_ACCESS_TOKEN}`
       };
   
       // Make request
       const response = await fetch(apiEndpoint, {
         method: "POST",
-        headers: headers,
+        headers: {
+          ...headers,
+          "Authorization": `Bearer ${getToken()}`
+        },
         body: JSON.stringify({
           query: query,
           variables: {


### PR DESCRIPTION
should be hidden decently enough for scrapers, there is not that much reason to hide it. Token is scoped to read only and there is no billing inforamation attached to it. I am calling this a day if GitHub will leave it alone.
